### PR TITLE
Revert "Bump micronaut-openapi from 3.2.0 to 4.0.0"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,7 +105,7 @@ dependencies {
     implementation("io.github.microutils:kotlin-logging-jvm:2.1.21")
     runtimeOnly("ch.qos.logback:logback-classic")
 
-    kapt("io.micronaut.openapi:micronaut-openapi:4.0.0")
+    kapt("io.micronaut.openapi:micronaut-openapi:3.2.0")
     implementation("io.swagger.core.v3:swagger-annotations")
 
     // Core persistence support with Micronaut Data


### PR DESCRIPTION
Reverts ThoughtWorks-SEA/recce#115

Seems to have broken things.