### PR TITLE
164 fix basic auth header in rapidoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ These options require only JDK 11+ and Docker installed locally.
       -e AUTH_USERNAME=admin -e AUTH_PASSWORD=admin \
       -e MICRONAUT_CONFIG_FILES=/examples/scenario/petshop-mariadb/application-petshop-mariadb.yml \
       -e DATABASE_HOST=host.docker.internal \
-      -e R2DBC_DATASOURCES_SOURCE_URL=r2dbc:pool:mysql://host.docker.internal:8000/db \
-      -e R2DBC_DATASOURCES_TARGET_URL=r2dbc:pool:mysql://host.docker.internal:8001/db \
+      -e R2DBC_DATASOURCES_SOURCE_URL=r2dbc:pool:mariadb://host.docker.internal:8000/db \
+      -e R2DBC_DATASOURCES_TARGET_URL=r2dbc:pool:mariadb://host.docker.internal:8001/db \
       ghcr.io/thoughtworks-sea/recce-server:latest
     ```
     

--- a/src/main/kotlin/recce/server/RecceServer.kt
+++ b/src/main/kotlin/recce/server/RecceServer.kt
@@ -24,7 +24,7 @@ private val logger = KotlinLogging.logger {}
     externalDocs = ExternalDocumentation(description = "Server Docs", url = "$GITHUB_PROJECT/README.md"),
     security = [SecurityRequirement(name = "basicAuth")]
 )
-@SecuritySchemes(SecurityScheme(name = "basicAuth", type = SecuritySchemeType.HTTP, scheme = "basic"))
+@SecuritySchemes(SecurityScheme(paramName = "Authorization", name = "basicAuth", type = SecuritySchemeType.HTTP, scheme = "basic"))
 object RecceServer {
 
     @JvmStatic

--- a/src/test/kotlin/recce/server/auth/BasicAuthenticationProviderTest.kt
+++ b/src/test/kotlin/recce/server/auth/BasicAuthenticationProviderTest.kt
@@ -30,6 +30,17 @@ class BasicAuthenticationProviderTest {
     }
 
     @Test
+    fun `returns 401 UNAUTHORIZED when accessing a secured URL with invalid credentials`() {
+        Given {
+            spec(spec).auth().preemptive().basic("unknown", authConfig.password)
+        } When {
+            get("/datasets")
+        } Then {
+            statusCode(UNAUTHORIZED.code)
+        }
+    }
+
+    @Test
     fun `returns 401 UNAUTHORIZED when accessing a secured URL without authenticating`() {
         Given {
             spec(spec)


### PR DESCRIPTION
Follow up with #164 .

Curl command works `curl 'http://localhost:8080/runs/35' -u "admin:admin"`, but trying with http://localhost:8080/rapidoc/ doesn't work. it seems the recce-server is authenticating the user correctly with basic auth, ie. `Authorization` request header. However, the rapidoc/swagger was configured to use request header `basicAuth`.

Thus, making this change, with the following reference.
- [Javadoc: OpenAPI SecurityScheme](https://github.com/swagger-api/swagger-core/blob/0a16eb7c9be4475e90957e3b91b6e03ace5124f6/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/security/SecurityScheme.java#L49-L55)
- [Security Scheme Object](https://swagger.io/specification/#security-scheme-object)

In the [main commit](https://github.com/ThoughtWorks-SEA/recce/commit/daf71393b02d1530e26cd4faefa395ed29b12237), I added a test to verify when given invalid credentials.

I didn't commit the following test to verify the generated request header because it feels noisy to me. The configuration is done through annotations and the impact area is the swagger/rapidoc. 
Is there better version of this test? 🤔  
```java
        Given {
            spec(spec).auth().basic(authConfig.username, authConfig.password).header("Authorization", "rubbish")
        } When {
            get("/datasets")
        } Then {
            statusCode(OK.code) // this will fail the test, returning 401.
        }
```