### PR TITLE
Revert "Bump org.owasp.dependencycheck from 7.4.4 to 8.0.0"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
     id("com.adarshr.test-logger") version "3.2.0"
     id("com.google.cloud.tools.jib") version "3.3.1"
     id("org.ajoberstar.reckon") version "0.16.1"
-    id("org.owasp.dependencycheck") version "8.0.0"
+    id("org.owasp.dependencycheck") version "7.4.4"
 }
 
 group = "recce.server"


### PR DESCRIPTION
Reverts ThoughtWorks-SEA/recce#327 due to https://github.com/dependency-check/dependency-check-gradle/issues/304